### PR TITLE
Fix game canvas resolution on Retina displays

### DIFF
--- a/breakout.js
+++ b/breakout.js
@@ -82,16 +82,24 @@ function initLevel(n) {
 
 // Resize on viewport size change
 function resizeCanvas() {
-    canvas.width = window.innerWidth > window.innerHeight*1.33 ? window.innerHeight*1.33 : window.innerWidth;
-    canvas.height = canvas.width/2;
-    container.style.width = canvas.width+'px';
-    document.body.style.fontSize = canvas.width*0.02+'px';
+    var width = window.innerWidth > window.innerHeight*1.33 ? window.innerHeight*1.33 : window.innerWidth;
+    var height = width / 2;
+    var scale = window.devicePixelRatio || 1;
+
+    container.style.width = width + 'px';
+    document.body.style.fontSize = width * 0.02 + 'px';
+    canvas.width = width * scale;
+    canvas.height = height * scale;
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
+
+    ctx.scale(scale, scale);
     ctx.fillStyle = color.background;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    gU = canvas.width/gw;
+    ctx.fillRect(0, 0, width, height);
+    gU = width/gw;
     ball.style.width = r*2*gU+'px';
     ball.style.height = r*2*gU+'px';
-    paddle.style.top = canvas.offsetTop+canvas.height-(paddleHeight+1)*gU+'px';
+    paddle.style.top = canvas.offsetTop+height-(paddleHeight+1)*gU+'px';
     paddle.style.width = paddleWidth*gU+'px';
     paddle.style.height = paddleHeight*gU+'px';
     ctx.fillStyle = color.brick;


### PR DESCRIPTION
Currently the game on the homepage appears to be blurry on Retina displays due to scaling issues. This PR fixes that. Here is the [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) (scroll down to "Correcting resolution in `<canvas>`").

Before | After
--- | ---
<img alt="Before" src="https://user-images.githubusercontent.com/40002855/78322129-a5401680-7522-11ea-8b17-c916d02a3244.png"> | <img alt="After" src="https://user-images.githubusercontent.com/40002855/78322131-a709da00-7522-11ea-860c-94e8a56806d9.png">

_Note: view the images in fullscreen to see the difference._
